### PR TITLE
Turn on Travis Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+dist: trusty
+language: python
+python:
+    - 3.6.1  # This should match with runtime.txt
+install:
+    - pip install flake8
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
+    # exit-zero treates all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script: true
+notifications:
+    on_success: change
+    on_failure: change  # `always` might be the setting once code changes slow down


### PR DESCRIPTION
The goal of this change is to have Travis-CI automatically run [flake8](http://flake8.readthedocs.io) (and later other) tests on every pull request. This will help contributors know if their submissions are going to _break the build_. To turn on this **free** service, the repo owner would need to do steps 1 and 2 of https://docs.travis-ci.com/user/getting-started/  Automated testing is helping projects move faster.
